### PR TITLE
ci: add pipeline for linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+---
+name: CI Build
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  sca:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Set up Python 3.10'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r dev-requirements.txt
+      - name: SCA
+        run: |
+          flawfinder src/
+      - name: Lint
+        run: |
+          isort --check **/*.py
+          black --check **/*.py
+  build:
+    runs-on: ubuntu-latest
+    needs: [version, sca]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install base dependencies
+        run: apt-get install -y libnss3 libnss3-dev libnss3-tools gcc
+      - name: 'Set up Python 3.10'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build
+          python -m pip install -r requirements.txt
+      - name: Validate build environment
+        run: bindep --file bindep.txt
+      - name: Perform build
+        run: python setup.py bdist_wheel
+      - name: Download versioned files
+        uses: actions/download-artifact@v3
+        with:
+          name: dist/python_nss-*-linux_x86_64.whl
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install base dependencies
+        run: apt-get install -y libnss3 libnss3-tools
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: actions/setup-python@v2
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Download versioned files
+        uses: actions/download-artifact@v3
+        with:
+          name: dist/python_nss-*-linux_x86_64.whl
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r dev-requirements.txt
+      # - name: Validate test environment
+      #   run: bindep --file bindep.txt runtime
+      - name: Run test suite
+        run: ./tests/run_tests.py
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Set up Python 3.10'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Download versioned files
+        uses: actions/download-artifact@v3
+        with:
+          name: dist/python_nss-*-linux_x86_64.whl
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install twine
+      - name: Publish artifacts
+        run: |
+          twine upload \
+            --non-interactive \
+            --skip-existing \
+            --repository 'https://test.pypi.org/legacy/' \
+            --username __token__ \
+            --password "${{ secrets.TESTPYPI_TOKEN }}"

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,9 +1,14 @@
+libnss3 [platform:ubuntu]
+libnss3-dev [platform:ubuntu]
+libnss3-tools [platform:ubuntu]
+
 nss-devel [platform:rpm]
 nss-tools [platform:rpm]
 nspr-devel [platform:rpm]
 
-python3 [platform:rpm]
+python3-dev [platform:dpkg]
 python3-devel [platform:rpm]
-python3-pip [platform:rpm]
+python3-pip [platform:base-py3]
+python3 [platform:base-py3]
 
 gcc


### PR DESCRIPTION
*Overview*

CI/CD pipelines are needed to begin building python-nss. Currently, Ubunutu is provided by GitHub CI.

*Acceptance*

Pipeline must provide SCA, build, test, and publish wheels.